### PR TITLE
fixed aggregation skip example

### DIFF
--- a/source/reference/operator/aggregation/skip.txt
+++ b/source/reference/operator/aggregation/skip.txt
@@ -35,9 +35,9 @@ Consider the following example:
 
 .. code-block:: javascript
 
-   db.article.aggregate(
+   db.article.aggregate([
        { $skip : 5 }
-   );
+   ]);
 
 This operation skips the first 5 documents passed to it by the
 pipeline. :pipeline:`$skip` has no effect on the content of the


### PR DESCRIPTION
Sample code seems incorrect to me: aggregate() argument is an array
BEFORE : db.article.aggregate({ $skip : 5 });
AFTER : db.article.aggregate([{ $skip : 5 }]);

Willing to know if this ought to be ported to all version branches (and if not all, all from... which version ?).